### PR TITLE
zoxideの設定改善: fzf依存関係とziエイリアス競合を解決

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -110,4 +110,4 @@ fi
 eval "$(zoxide init zsh --cmd z)"
 
 # Create custom alias for zoxide interactive mode to avoid zinit conflict
-alias zii='z -i'
+alias zii='zoxide query -i'

--- a/.zshrc
+++ b/.zshrc
@@ -100,5 +100,14 @@ if ! command -v zoxide &> /dev/null; then
   brew install zoxide
 fi
 
-# Initialize zoxide
-eval "$(zoxide init zsh)"
+# Auto-install fzf with brew if not installed (required for zoxide interactive mode)
+if ! command -v fzf &> /dev/null; then
+  echo "Installing fzf with brew (required for zoxide interactive mode)..."
+  brew install fzf
+fi
+
+# Initialize zoxide with custom alias to avoid conflict with zinit's zi
+eval "$(zoxide init zsh --cmd z)"
+
+# Create custom alias for zoxide interactive mode to avoid zinit conflict
+alias zii='z -i'

--- a/docs/zoxide-usage.md
+++ b/docs/zoxide-usage.md
@@ -27,12 +27,14 @@ z doc              # ~/Documents に移動
 z down             # ~/Downloads に移動
 ```
 
-### ziコマンド（インタラクティブ選択）
+### ziiコマンド（インタラクティブ選択）
 
 ```bash
-zi                 # 訪問履歴から選択
-zi foo             # "foo"を含むディレクトリから選択
+zii                # 訪問履歴から選択
+zii foo            # "foo"を含むディレクトリから選択
 ```
+
+注意: `zi`コマンドはzinitと競合するため、このdotfilesでは`zii`として設定されています。
 
 ### よく使うコマンド
 
@@ -76,7 +78,7 @@ z my-awesome
 ```bash
 # project1, project2, project3 がある場合
 z project1         # 最も頻繁にアクセスするプロジェクトに移動
-zi project         # インタラクティブに選択
+zii project        # インタラクティブに選択
 ```
 
 ## データベースの管理


### PR DESCRIPTION
## 概要
- Issue #35 で報告されたzoxideの問題を解決
- fzfの自動インストール機能を追加
- zinitの`zi`エイリアスとの競合を解決

## 変更内容

### .zshrc の更新
- fzfの自動インストール機能を追加（zoxideインタラクティブモードに必須）
- zoxideの初期化を`--cmd z`オプション付きに変更してziとの競合を回避
- インタラクティブモード用に`zii`エイリアスを追加

### docs/zoxide-usage.md の更新
- `zi`コマンドを`zii`に変更
- エイリアス変更の説明を追加

## 解決した問題

1. **fzf依存関係の不備**
   - fzfが自動インストールされ、zoxideのインタラクティブモードが正常動作

2. **ziエイリアス競合**
   - zinitの`zi`エイリアスと競合しないよう、zoxideのインタラクティブ機能を`zii`に変更

## テスト内容
- [ ] 新しいシェルでfzfが自動インストールされることを確認
- [ ] `zi`がzinitのエイリアスとして正常動作することを確認  
- [ ] `zii`でzoxideのインタラクティブ選択が動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)