### PR TITLE
【サブタスク3】インストールスクリプトのマルチプラットフォーム対応と.gitconfig管理

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,48 @@
+# Core settings
+[core]
+    editor = vim
+    autocrlf = false
+    ignorecase = false
+    quotepath = false
+    precomposeunicode = true
+
+# Color settings
+[color]
+    ui = auto
+    diff = auto
+    status = auto
+    branch = auto
+
+# Alias settings
+[alias]
+    st = status
+    co = checkout
+    br = branch
+    ci = commit
+    df = diff
+    lg = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
+    lga = log --graph --all --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
+    unstage = reset HEAD --
+    last = log -1 HEAD
+    amend = commit --amend --reuse-message=HEAD
+
+# Push settings
+[push]
+    default = simple
+
+# Pull settings
+[pull]
+    rebase = false
+
+# Merge settings
+[merge]
+    ff = false
+
+# Diff settings
+[diff]
+    algorithm = histogram
+    indentHeuristic = true
+
+# Include local settings
+[include]
+    path = ~/.gitconfig.local

--- a/.zshrc
+++ b/.zshrc
@@ -109,16 +109,23 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     brew install fzf
   fi
 elif [[ "$(uname -s)" == "Linux" ]]; then
-  # Linux/Ubuntu: apt または手動インストール
+  # Linux/Ubuntu: apt を優先使用
   if ! command -v zoxide &> /dev/null; then
-    echo "zoxide is not installed. Please install it manually:"
-    echo "  curl -sS https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | bash"
+    if command -v apt &> /dev/null; then
+      echo "zoxide is not installed. Please install it:"
+      echo "  sudo apt update && sudo apt install zoxide"
+      echo ""
+      echo "Note: If zoxide is not available in apt (Ubuntu < 22.04), install it with:"
+      echo "  curl -sS https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | bash"
+    else
+      echo "zoxide is not installed. Please install it manually."
+    fi
   fi
   
   if ! command -v fzf &> /dev/null; then
     if command -v apt &> /dev/null; then
-      echo "Installing fzf with apt (required for zoxide interactive mode)..."
-      echo "Please run: sudo apt update && sudo apt install fzf"
+      echo "fzf is not installed. Please install it:"
+      echo "  sudo apt update && sudo apt install fzf"
     else
       echo "fzf is not installed. Please install it manually."
     fi

--- a/.zshrc
+++ b/.zshrc
@@ -23,8 +23,10 @@ HISTSIZE=10000
 SAVEHIST=10000
 ## ターミナルフォーマット
 export PROMPT="%F{magenta}%n%f:%F{yellow}%~%f %# "
-## zsh向けのhomebrew PATH設定
-export PATH="/opt/homebrew/bin:$PATH"
+## zsh向けのhomebrew PATH設定 (macOSのみ)
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    export PATH="/opt/homebrew/bin:$PATH"
+fi
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
@@ -94,20 +96,39 @@ zinit ice wait"2" lucid
 zinit light zsh-users/zsh-completions
 
 # zoxide setup
-# Auto-install zoxide with brew if not installed
-if ! command -v zoxide &> /dev/null; then
-  echo "Installing zoxide with brew..."
-  brew install zoxide
-fi
-
-# Auto-install fzf with brew if not installed (required for zoxide interactive mode)
-if ! command -v fzf &> /dev/null; then
-  echo "Installing fzf with brew (required for zoxide interactive mode)..."
-  brew install fzf
+# プラットフォーム判定
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  # macOS: brew を使用
+  if ! command -v zoxide &> /dev/null; then
+    echo "Installing zoxide with brew..."
+    brew install zoxide
+  fi
+  
+  if ! command -v fzf &> /dev/null; then
+    echo "Installing fzf with brew (required for zoxide interactive mode)..."
+    brew install fzf
+  fi
+elif [[ "$(uname -s)" == "Linux" ]]; then
+  # Linux/Ubuntu: apt または手動インストール
+  if ! command -v zoxide &> /dev/null; then
+    echo "zoxide is not installed. Please install it manually:"
+    echo "  curl -sS https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | bash"
+  fi
+  
+  if ! command -v fzf &> /dev/null; then
+    if command -v apt &> /dev/null; then
+      echo "Installing fzf with apt (required for zoxide interactive mode)..."
+      echo "Please run: sudo apt update && sudo apt install fzf"
+    else
+      echo "fzf is not installed. Please install it manually."
+    fi
+  fi
 fi
 
 # Initialize zoxide with custom alias to avoid conflict with zinit's zi
-eval "$(zoxide init zsh --cmd z)"
+if command -v zoxide &> /dev/null; then
+    eval "$(zoxide init zsh --cmd z)"
+fi
 
 # Create custom function for zoxide interactive mode to avoid zinit conflict
 function zii() {

--- a/install.sh
+++ b/install.sh
@@ -55,6 +55,15 @@ platform_init() {
                 echo "sudo apt update && sudo apt install git を実行してください。"
                 exit 1
             fi
+            
+            # zinitのインストール
+            if [ ! -d "$HOME/.local/share/zinit/zinit.git" ]; then
+                echo "zinitをインストールしています..."
+                bash -c "$(curl --fail --show-error --silent --location https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)"
+                echo "zinitのインストールが完了しました。"
+            else
+                echo "zinitは既にインストールされています。"
+            fi
             ;;
         *)
             echo "サポートされていないプラットフォームです: $PLATFORM"
@@ -114,9 +123,10 @@ handle_gitconfig() {
             echo ".gitconfig.local のinclude設定を追加しました。"
         fi
         
-        # バックアップから.gitconfig.localを作成（ユーザー設定以外）
+        # バックアップから.gitconfig.localを作成（ユーザー設定とinclude設定以外）
         if [ -f "$backup_gitconfig" ]; then
-            grep -v -E "^\[user\]|name =|email =" "$backup_gitconfig" > "$HOME/.gitconfig.local" 2>/dev/null || true
+            # userセクション、include設定、および.gitconfig.localへの参照を除外
+            grep -v -E "^\[user\]|^\[include\]|name =|email =|path = ~/\.gitconfig\.local" "$backup_gitconfig" > "$HOME/.gitconfig.local" 2>/dev/null || true
             echo "既存のカスタム設定を .gitconfig.local に保存しました。"
         fi
     else

--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,15 @@ platform_init() {
                 echo "https://brew.sh を参照してインストールしてください。"
                 exit 1
             fi
+            
+            # zinitのインストール（Homebrewを使用）
+            if ! command -v zinit &> /dev/null && [ ! -d "$HOME/.local/share/zinit/zinit.git" ]; then
+                echo "zinitをHomebrewでインストールしています..."
+                brew install zinit
+                echo "zinitのインストールが完了しました。"
+            else
+                echo "zinitは既にインストールされています。"
+            fi
             ;;
         ubuntu)
             echo "Ubuntu環境の初期化を実行..."


### PR DESCRIPTION
## 概要
dotfilesのインストールスクリプトをmacOSだけでなくUbuntuにも対応させ、.gitconfigの管理機能を追加しました。

## 変更内容
- `install.sh` にプラットフォーム判定機能を追加
  - macOSとUbuntuを自動判定する `detect_platform()` 関数を実装
  - OS固有の初期化処理 `platform_init()` を追加（Homebrew/gitの確認）
- .gitconfig管理機能を実装
  - 既存のuser.name/user.emailを保護
  - その他のカスタム設定を.gitconfig.localに退避
  - includeパスで.gitconfig.localを読み込む設定を自動追加
- 基本的な.gitconfigテンプレートを追加
  - エディタ、カラー、エイリアス、push/pull/merge/diff設定を含む

## テスト計画
- [x] macOSでのクリーンインストールテスト
- [ ] Ubuntuでのクリーンインストールテスト
- [x] 既存の.gitconfigがある環境でのインストールテスト
  - [x] user.name/user.emailが保持されることを確認
  - [x] カスタム設定が.gitconfig.localに移行されることを確認
- [ ] .gitconfig.localのinclude設定が正しく動作することを確認

## 関連ISSUE
Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)