### PR TITLE
make install実行後の設定自動反映機能を追加

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -202,3 +202,25 @@ if [ -d "${DOTFILES_DIR}/scripts" ]; then
         fi
     done
 fi
+
+# インストール完了後にシェル設定を再読み込み
+echo ""
+echo "インストールが完了しました。"
+echo "現在のシェルセッションに設定を反映しています..."
+
+# 現在のシェルがzshの場合、.zshrcを再読み込み
+if [ -n "$ZSH_VERSION" ]; then
+    if [ -f "$HOME/.zshrc" ]; then
+        echo "zsh設定を再読み込みしています..."
+        source "$HOME/.zshrc" 2>/dev/null && echo "✓ zsh設定の再読み込みが完了しました。" || echo "! zsh設定の再読み込みでエラーが発生しましたが、新しいターミナルでは正常に動作します。"
+    fi
+elif [ -n "$BASH_VERSION" ]; then
+    if [ -f "$HOME/.bashrc" ]; then
+        echo "bash設定を再読み込みしています..."
+        source "$HOME/.bashrc" 2>/dev/null && echo "✓ bash設定の再読み込みが完了しました。" || echo "! bash設定の再読み込みでエラーが発生しましたが、新しいターミナルでは正常に動作します。"
+    fi
+fi
+
+echo ""
+echo "🎉 dotfilesのセットアップが完了しました！"
+echo "新しい機能やコマンドが利用可能になりました。"


### PR DESCRIPTION
## 概要
`make install`実行後に新しいターミナルを開かなくても設定変更が現在のシェルセッションに自動的に反映されるように改善しました。

## 変更内容
- install.sh完了後にシェル設定の自動再読み込み機能を追加
- zsh/bash両方に対応した設定ファイル再読み込み処理
- エラーハンドリングによる安全な処理
- わかりやすいユーザーメッセージの表示

## テスト計画
- [ ] macOS環境でのzsh動作確認
- [ ] Ubuntu環境でのbash動作確認  
- [ ] 手動テストのシナリオ
  - シナリオ1: make install実行後、同一ターミナルで新機能が使用可能
  - シナリオ2: エラーが発生しても適切なメッセージが表示される
  - シナリオ3: 既存の動作に影響がない

## 関連ISSUE
Closes #49

🤖 Generated with [Claude Code](https://claude.ai/code)