### PR TITLE
ワークツリー作成場所の説明を追加

### DIFF
--- a/docs/claude-task-workflow.md
+++ b/docs/claude-task-workflow.md
@@ -52,6 +52,7 @@ git checkout main
 git pull origin main
 
 # ワークツリーを作成（wtコマンドを使用）
+# 作成場所はカレントディレクトリの配下のworktrees/
 wt create feature/issue-番号-概要
 
 # 作成したワークツリーに移動


### PR DESCRIPTION
## 概要
Claude task workflowドキュメントにワークツリーの作成場所についての説明を追加しました。

## 変更内容
- docs/claude-task-workflow.mdのワークツリー作成コマンドにコメントを追加
- カレントディレクトリの配下のworktrees/に作成することを明記

## テスト計画
- [ ] ドキュメントの内容確認
- [ ] ワークツリー作成の説明が明確であることを確認

## 関連ISSUE
Closes #73

🤖 Generated with [Claude Code](https://claude.ai/code)