### PR TITLE
feat: iTerm2の設定とセットアップ環境を追加

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,40 @@
+# Homebrew Bundle file for managing applications
+
+# Taps
+tap "homebrew/bundle"
+tap "homebrew/cask"
+tap "homebrew/core"
+
+# Terminal emulators
+cask "iterm2"
+
+# Development tools
+brew "git"
+brew "gh"
+brew "neovim"
+brew "tmux"
+
+# Shell and utilities
+brew "zsh"
+brew "starship"
+brew "fzf"
+brew "ripgrep"
+brew "bat"
+brew "eza"
+brew "zoxide"
+
+# Programming languages
+brew "node"
+brew "python@3.12"
+brew "go"
+brew "rust"
+
+# Container tools
+brew "docker"
+brew "docker-compose"
+
+# Other utilities
+brew "jq"
+brew "tree"
+brew "wget"
+brew "curl"

--- a/README.md
+++ b/README.md
@@ -145,6 +145,42 @@ $ git config --file ~/.gitconfig.local user.email "your.email@example.com"
 $ git config --file ~/.gitconfig.local core.editor "your-favorite-editor"
 ```
 
+## iTerm2の設定
+
+### インストール
+```sh
+# Brewfileを使用してiTerm2をインストール
+$ brew bundle
+
+# または個別にインストール
+$ brew install --cask iterm2
+```
+
+### セットアップ
+```sh
+# iTerm2の設定をセットアップ
+$ ./scripts/setup_iterm2.sh
+```
+
+このスクリプトは以下を実行します：
+1. iTerm2のインストール（未インストールの場合）
+2. 推奨設定ファイルの配置
+3. MesloLGS NFフォントのインストール（Powerline対応）
+4. カスタム設定フォルダの指定
+
+### 設定内容
+- **カラースキーム**: ダークテーマ（カスタム）
+- **フォント**: MesloLGS NF 14pt（Powerline対応）
+- **スクロールバック**: 10,000行
+- **ホットキー**: 設定済み
+- **ペイン分割**: ディマー設定
+- **マウスレポート**: 有効
+- **その他**: tmux統合、コマンド履歴、ペースト履歴
+
+### カスタマイズ
+iTerm2の設定は`iterm2/com.googlecode.iterm2.plist`で管理されています。
+設定を変更する場合は、iTerm2の設定画面から変更し、設定ファイルをコミットしてください。
+
 ## 注意事項
 
 - **秘密情報を含むファイル**（`.aws`、秘密鍵など）は**絶対に**このリポジトリに含めないでください

--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ $ ./scripts/setup_iterm2.sh
 iTerm2の設定は`iterm2/com.googlecode.iterm2.plist`で管理されています。
 設定を変更する場合は、iTerm2の設定画面から変更し、設定ファイルをコミットしてください。
 
+### ファイル構成
+| ファイル | 説明 |
+|---------|------|
+| `Brewfile` | iTerm2を含む開発ツールの定義（[Homebrew Bundle](https://github.com/Homebrew/homebrew-bundle)） |
+| `iterm2/com.googlecode.iterm2.plist` | iTerm2の設定ファイル（カラー、フォント、キーバインド等） |
+| `scripts/setup_iterm2.sh` | 自動セットアップスクリプト |
+| `scripts/process_iterm2_config.sh` | 設定ファイルの変数置換処理 |
+
+### 参考リンク
+- [iTerm2公式サイト](https://iterm2.com/)
+- [MesloLGS Nerd Font](https://github.com/ryanoasis/nerd-fonts)
+
 ## 注意事項
 
 - **秘密情報を含むファイル**（`.aws`、秘密鍵など）は**絶対に**このリポジトリに含めないでください

--- a/install.sh
+++ b/install.sh
@@ -143,6 +143,35 @@ for dotfile in "${DOTFILES_DIR}"/.??*; do
 
 done
 
+# iTerm2設定ディレクトリの処理
+if [ -d "${DOTFILES_DIR}/iterm2" ]; then
+    echo "iTerm2設定をセットアップしています..."
+    
+    # iTerm2の設定ディレクトリを確保
+    ITERM2_PREFS_DIR="$HOME/Library/Preferences"
+    if [ ! -d "$ITERM2_PREFS_DIR" ]; then
+        mkdir -p "$ITERM2_PREFS_DIR"
+    fi
+    
+    # plistファイルを処理してコピー
+    if [ -f "${DOTFILES_DIR}/iterm2/com.googlecode.iterm2.plist" ]; then
+        if [ -f "${DOTFILES_DIR}/scripts/process_iterm2_config.sh" ]; then
+            "${DOTFILES_DIR}/scripts/process_iterm2_config.sh" \
+                "${DOTFILES_DIR}/iterm2/com.googlecode.iterm2.plist" \
+                "$ITERM2_PREFS_DIR/com.googlecode.iterm2.plist"
+            echo "iTerm2設定ファイルを処理してコピーしました。"
+        else
+            cp "${DOTFILES_DIR}/iterm2/com.googlecode.iterm2.plist" "$ITERM2_PREFS_DIR/"
+            echo "iTerm2設定ファイルをコピーしました。"
+        fi
+        
+        # iTerm2にカスタム設定フォルダを使用するよう指示
+        defaults write com.googlecode.iterm2 LoadPrefsFromCustomFolder -bool true
+        defaults write com.googlecode.iterm2 PrefsCustomFolder -string "${DOTFILES_DIR}/iterm2"
+        echo "iTerm2がカスタム設定フォルダを使用するよう設定しました。"
+    fi
+fi
+
 # scriptsディレクトリ内のシェルスクリプトを$HOME/binにシンボリックリンク作成
 echo "Creating symlinks for scripts in $HOME/bin..."
 

--- a/iterm2/com.googlecode.iterm2.plist
+++ b/iterm2/com.googlecode.iterm2.plist
@@ -599,7 +599,7 @@
 			<key>Window Type</key>
 			<integer>0</integer>
 			<key>Working Directory</key>
-			<string>/Users/username</string>
+			<string>/Users/$USER</string>
 		</dict>
 	</array>
 	<key>NoSyncHaveWarnedAboutPasteConfirmationChange</key>

--- a/iterm2/com.googlecode.iterm2.plist
+++ b/iterm2/com.googlecode.iterm2.plist
@@ -1,0 +1,719 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Default Bookmark Guid</key>
+	<string>F0E5DEFE-7A16-4A5C-B8C5-9E8E5A5F2940</string>
+	<key>DimBackgroundWindows</key>
+	<false/>
+	<key>DimInactiveSplitPanes</key>
+	<true/>
+	<key>DimOnlyText</key>
+	<false/>
+	<key>DisableFullscreenTransparency</key>
+	<false/>
+	<key>EnableRendezvous</key>
+	<false/>
+	<key>HideActivityIndicator</key>
+	<false/>
+	<key>HideMenuBarInFullscreen</key>
+	<true/>
+	<key>HideScrollbar</key>
+	<true/>
+	<key>HideTab</key>
+	<false/>
+	<key>HighlightTabLabels</key>
+	<true/>
+	<key>HotKeyMiniaturize</key>
+	<true/>
+	<key>JobName</key>
+	<true/>
+	<key>LoadPrefsFromCustomFolder</key>
+	<true/>
+	<key>NSNavLastRootDirectory</key>
+	<string>~/dotfiles/iterm2</string>
+	<key>New Bookmarks</key>
+	<array>
+		<dict>
+			<key>ASCII Anti Aliased</key>
+			<true/>
+			<key>Allow Title Setting</key>
+			<true/>
+			<key>Ambiguous Double Width</key>
+			<false/>
+			<key>Ansi 0 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.0</real>
+				<key>Green Component</key>
+				<real>0.0</real>
+				<key>Red Component</key>
+				<real>0.0</real>
+			</dict>
+			<key>Ansi 1 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.0</real>
+				<key>Green Component</key>
+				<real>0.0</real>
+				<key>Red Component</key>
+				<real>0.73333334922790527</real>
+			</dict>
+			<key>Ansi 10 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.3333333432674408</real>
+				<key>Green Component</key>
+				<real>1</real>
+				<key>Red Component</key>
+				<real>0.3333333432674408</real>
+			</dict>
+			<key>Ansi 11 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.3333333432674408</real>
+				<key>Green Component</key>
+				<real>1</real>
+				<key>Red Component</key>
+				<real>1</real>
+			</dict>
+			<key>Ansi 12 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>1</real>
+				<key>Green Component</key>
+				<real>0.3333333432674408</real>
+				<key>Red Component</key>
+				<real>0.3333333432674408</real>
+			</dict>
+			<key>Ansi 13 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>1</real>
+				<key>Green Component</key>
+				<real>0.3333333432674408</real>
+				<key>Red Component</key>
+				<real>1</real>
+			</dict>
+			<key>Ansi 14 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>1</real>
+				<key>Green Component</key>
+				<real>1</real>
+				<key>Red Component</key>
+				<real>0.3333333432674408</real>
+			</dict>
+			<key>Ansi 15 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>1</real>
+				<key>Green Component</key>
+				<real>1</real>
+				<key>Red Component</key>
+				<real>1</real>
+			</dict>
+			<key>Ansi 2 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.0</real>
+				<key>Green Component</key>
+				<real>0.73333334922790527</real>
+				<key>Red Component</key>
+				<real>0.0</real>
+			</dict>
+			<key>Ansi 3 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.0</real>
+				<key>Green Component</key>
+				<real>0.73333334922790527</real>
+				<key>Red Component</key>
+				<real>0.73333334922790527</real>
+			</dict>
+			<key>Ansi 4 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.73333334922790527</real>
+				<key>Green Component</key>
+				<real>0.0</real>
+				<key>Red Component</key>
+				<real>0.0</real>
+			</dict>
+			<key>Ansi 5 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.73333334922790527</real>
+				<key>Green Component</key>
+				<real>0.0</real>
+				<key>Red Component</key>
+				<real>0.73333334922790527</real>
+			</dict>
+			<key>Ansi 6 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.73333334922790527</real>
+				<key>Green Component</key>
+				<real>0.73333334922790527</real>
+				<key>Red Component</key>
+				<real>0.0</real>
+			</dict>
+			<key>Ansi 7 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.73333334922790527</real>
+				<key>Green Component</key>
+				<real>0.73333334922790527</real>
+				<key>Red Component</key>
+				<real>0.73333334922790527</real>
+			</dict>
+			<key>Ansi 8 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.3333333432674408</real>
+				<key>Green Component</key>
+				<real>0.3333333432674408</real>
+				<key>Red Component</key>
+				<real>0.3333333432674408</real>
+			</dict>
+			<key>Ansi 9 Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.3333333432674408</real>
+				<key>Green Component</key>
+				<real>0.3333333432674408</real>
+				<key>Red Component</key>
+				<real>1</real>
+			</dict>
+			<key>Background Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.0</real>
+				<key>Green Component</key>
+				<real>0.0</real>
+				<key>Red Component</key>
+				<real>0.0</real>
+			</dict>
+			<key>Blinking Cursor</key>
+			<true/>
+			<key>Blur</key>
+			<false/>
+			<key>Bold Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>1</real>
+				<key>Green Component</key>
+				<real>1</real>
+				<key>Red Component</key>
+				<real>1</real>
+			</dict>
+			<key>Character Encoding</key>
+			<integer>4</integer>
+			<key>Close Sessions On End</key>
+			<true/>
+			<key>Columns</key>
+			<integer>120</integer>
+			<key>Command</key>
+			<string></string>
+			<key>Cursor Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.73333334922790527</real>
+				<key>Green Component</key>
+				<real>0.73333334922790527</real>
+				<key>Red Component</key>
+				<real>0.73333334922790527</real>
+			</dict>
+			<key>Cursor Text Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>1</real>
+				<key>Green Component</key>
+				<real>1</real>
+				<key>Red Component</key>
+				<real>1</real>
+			</dict>
+			<key>Cursor Type</key>
+			<integer>2</integer>
+			<key>Custom Command</key>
+			<string>No</string>
+			<key>Custom Directory</key>
+			<string>Recycle</string>
+			<key>Default Bookmark</key>
+			<string>No</string>
+			<key>Description</key>
+			<string>Default</string>
+			<key>Disable Window Resizing</key>
+			<true/>
+			<key>Draw Powerline Glyphs</key>
+			<true/>
+			<key>Flashing Bell</key>
+			<false/>
+			<key>Foreground Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.73333334922790527</real>
+				<key>Green Component</key>
+				<real>0.73333334922790527</real>
+				<key>Red Component</key>
+				<real>0.73333334922790527</real>
+			</dict>
+			<key>Guid</key>
+			<string>F0E5DEFE-7A16-4A5C-B8C5-9E8E5A5F2940</string>
+			<key>Horizontal Spacing</key>
+			<real>1</real>
+			<key>Idle Code</key>
+			<integer>0</integer>
+			<key>Jobs to Ignore</key>
+			<array>
+				<string>rlogin</string>
+				<string>ssh</string>
+				<string>slogin</string>
+				<string>telnet</string>
+			</array>
+			<key>Keyboard Map</key>
+			<dict>
+				<key>0x2d-0x40000</key>
+				<dict>
+					<key>Action</key>
+					<integer>11</integer>
+					<key>Text</key>
+					<string>0x1f</string>
+				</dict>
+				<key>0x32-0x40000</key>
+				<dict>
+					<key>Action</key>
+					<integer>11</integer>
+					<key>Text</key>
+					<string>0x00</string>
+				</dict>
+				<key>0x33-0x40000</key>
+				<dict>
+					<key>Action</key>
+					<integer>11</integer>
+					<key>Text</key>
+					<string>0x1b</string>
+				</dict>
+				<key>0x34-0x40000</key>
+				<dict>
+					<key>Action</key>
+					<integer>11</integer>
+					<key>Text</key>
+					<string>0x1c</string>
+				</dict>
+				<key>0x35-0x40000</key>
+				<dict>
+					<key>Action</key>
+					<integer>11</integer>
+					<key>Text</key>
+					<string>0x1d</string>
+				</dict>
+				<key>0x36-0x40000</key>
+				<dict>
+					<key>Action</key>
+					<integer>11</integer>
+					<key>Text</key>
+					<string>0x1e</string>
+				</dict>
+				<key>0x37-0x40000</key>
+				<dict>
+					<key>Action</key>
+					<integer>11</integer>
+					<key>Text</key>
+					<string>0x1f</string>
+				</dict>
+				<key>0x38-0x40000</key>
+				<dict>
+					<key>Action</key>
+					<integer>11</integer>
+					<key>Text</key>
+					<string>0x7f</string>
+				</dict>
+				<key>0xf700-0x220000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;2A</string>
+				</dict>
+				<key>0xf700-0x240000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;5A</string>
+				</dict>
+				<key>0xf700-0x260000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;6A</string>
+				</dict>
+				<key>0xf701-0x220000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;2B</string>
+				</dict>
+				<key>0xf701-0x240000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;5B</string>
+				</dict>
+				<key>0xf701-0x260000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;6B</string>
+				</dict>
+				<key>0xf702-0x220000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;2D</string>
+				</dict>
+				<key>0xf702-0x240000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;5D</string>
+				</dict>
+				<key>0xf702-0x260000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;6D</string>
+				</dict>
+				<key>0xf703-0x220000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;2C</string>
+				</dict>
+				<key>0xf703-0x240000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;5C</string>
+				</dict>
+				<key>0xf703-0x260000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;6C</string>
+				</dict>
+				<key>0xf704-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;2P</string>
+				</dict>
+				<key>0xf705-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;2Q</string>
+				</dict>
+				<key>0xf706-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;2R</string>
+				</dict>
+				<key>0xf707-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;2S</string>
+				</dict>
+				<key>0xf708-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[15;2~</string>
+				</dict>
+				<key>0xf709-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[17;2~</string>
+				</dict>
+				<key>0xf70a-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[18;2~</string>
+				</dict>
+				<key>0xf70b-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[19;2~</string>
+				</dict>
+				<key>0xf70c-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[20;2~</string>
+				</dict>
+				<key>0xf70d-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[21;2~</string>
+				</dict>
+				<key>0xf70e-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[23;2~</string>
+				</dict>
+				<key>0xf70f-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[24;2~</string>
+				</dict>
+				<key>0xf729-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;2H</string>
+				</dict>
+				<key>0xf729-0x40000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;5H</string>
+				</dict>
+				<key>0xf72b-0x20000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;2F</string>
+				</dict>
+				<key>0xf72b-0x40000</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Text</key>
+					<string>[1;5F</string>
+				</dict>
+			</dict>
+			<key>Minimum Contrast</key>
+			<real>0.0</real>
+			<key>Mouse Reporting</key>
+			<true/>
+			<key>Name</key>
+			<string>Default</string>
+			<key>Non Ascii Font</key>
+			<string>Monaco 12</string>
+			<key>Non-ASCII Anti Aliased</key>
+			<true/>
+			<key>Normal Font</key>
+			<string>MesloLGS-NF-Regular 14</string>
+			<key>Option Key Sends</key>
+			<integer>0</integer>
+			<key>Prompt Before Closing 2</key>
+			<false/>
+			<key>Right Option Key Sends</key>
+			<integer>0</integer>
+			<key>Rows</key>
+			<integer>35</integer>
+			<key>Screen</key>
+			<integer>-1</integer>
+			<key>Scrollback Lines</key>
+			<integer>10000</integer>
+			<key>Selected Text Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>0.0</real>
+				<key>Green Component</key>
+				<real>0.0</real>
+				<key>Red Component</key>
+				<real>0.0</real>
+			</dict>
+			<key>Selection Color</key>
+			<dict>
+				<key>Blue Component</key>
+				<real>1</real>
+				<key>Green Component</key>
+				<real>0.8353000283241272</real>
+				<key>Red Component</key>
+				<real>0.70980000495910645</real>
+			</dict>
+			<key>Send Code When Idle</key>
+			<false/>
+			<key>Shortcut</key>
+			<string></string>
+			<key>Silence Bell</key>
+			<false/>
+			<key>Sync Title</key>
+			<false/>
+			<key>Tags</key>
+			<array/>
+			<key>Terminal Type</key>
+			<string>xterm-256color</string>
+			<key>Transparency</key>
+			<real>0.0</real>
+			<key>Unlimited Scrollback</key>
+			<false/>
+			<key>Use Bold Font</key>
+			<true/>
+			<key>Use Bright Bold</key>
+			<true/>
+			<key>Use Italic Font</key>
+			<true/>
+			<key>Use Non-ASCII Font</key>
+			<false/>
+			<key>Vertical Spacing</key>
+			<real>1</real>
+			<key>Visual Bell</key>
+			<true/>
+			<key>Window Type</key>
+			<integer>0</integer>
+			<key>Working Directory</key>
+			<string>/Users/username</string>
+		</dict>
+	</array>
+	<key>NoSyncHaveWarnedAboutPasteConfirmationChange</key>
+	<true/>
+	<key>NoSyncInstallationId</key>
+	<string>XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX</string>
+	<key>NoSyncPermissionToShowTip</key>
+	<false/>
+	<key>NoSyncTimeOfFirstLaunchOfVersionWithTip</key>
+	<real>0</real>
+	<key>OnlyWhenMoreTabs</key>
+	<true/>
+	<key>OpenArrangementAtStartup</key>
+	<false/>
+	<key>OpenNoWindowsAtStartup</key>
+	<false/>
+	<key>PassOnControlClick</key>
+	<false/>
+	<key>PasteHistoryMaxSize</key>
+	<integer>20</integer>
+	<key>PointerActions</key>
+	<dict>
+		<key>Button,1,1,,</key>
+		<dict>
+			<key>Action</key>
+			<string>kContextMenuPointerAction</string>
+		</dict>
+		<key>Button,2,1,,</key>
+		<dict>
+			<key>Action</key>
+			<string>kPasteFromSelectionPointerAction</string>
+		</dict>
+		<key>Gesture,ThreeFingerSwipeDown,,</key>
+		<dict>
+			<key>Action</key>
+			<string>kPrevWindowPointerAction</string>
+		</dict>
+		<key>Gesture,ThreeFingerSwipeLeft,,</key>
+		<dict>
+			<key>Action</key>
+			<string>kPrevTabPointerAction</string>
+		</dict>
+		<key>Gesture,ThreeFingerSwipeRight,,</key>
+		<dict>
+			<key>Action</key>
+			<string>kNextTabPointerAction</string>
+		</dict>
+		<key>Gesture,ThreeFingerSwipeUp,,</key>
+		<dict>
+			<key>Action</key>
+			<string>kNextWindowPointerAction</string>
+		</dict>
+	</dict>
+	<key>PrefsCustomFolder</key>
+	<string>~/dotfiles/iterm2</string>
+	<key>PromptOnQuit</key>
+	<true/>
+	<key>QuitWhenAllWindowsClosed</key>
+	<false/>
+	<key>RightCommand</key>
+	<integer>8</integer>
+	<key>RightOption</key>
+	<integer>3</integer>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUFeedAlternateAppNameKey</key>
+	<string>iTerm</string>
+	<key>SUFeedURL</key>
+	<string>https://iterm2.com/appcasts/final.xml?shard=52</string>
+	<key>SUHasLaunchedBefore</key>
+	<true/>
+	<key>SULastCheckTime</key>
+	<date>2023-01-01T00:00:00Z</date>
+	<key>SUSendProfileInfo</key>
+	<false/>
+	<key>Selection Respects Soft Boundaries</key>
+	<true/>
+	<key>ShowBookmarkName</key>
+	<false/>
+	<key>ShowFullScreenTabBar</key>
+	<true/>
+	<key>ShowNewOutputIndicator</key>
+	<true/>
+	<key>ShowPaneTitles</key>
+	<true/>
+	<key>SmartPlacement</key>
+	<false/>
+	<key>SplitPaneDimmingAmount</key>
+	<real>0.40000000596046448</real>
+	<key>StretchTabsToFillBar</key>
+	<false/>
+	<key>SwitchTabModifier</key>
+	<integer>4</integer>
+	<key>SwitchWindowModifier</key>
+	<integer>6</integer>
+	<key>TabStyle</key>
+	<integer>0</integer>
+	<key>TabViewType</key>
+	<integer>0</integer>
+	<key>ToolbeltTools</key>
+	<array>
+		<string>Profiles</string>
+		<string>Paste History</string>
+		<string>Command History</string>
+	</array>
+	<key>UseLionStyleFullscreen</key>
+	<true/>
+	<key>WindowNumber</key>
+	<true/>
+	<key>WindowStyle</key>
+	<integer>0</integer>
+	<key>WordCharacters</key>
+	<string>/-+\~_.</string>
+	<key>iTerm Version</key>
+	<string>3.4.19</string>
+</dict>
+</plist>

--- a/scripts/process_iterm2_config.sh
+++ b/scripts/process_iterm2_config.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# iTerm2設定ファイルのテンプレート処理スクリプト
+# $USERなどの変数を実際の値に置換します
+
+set -e
+
+# 入力と出力のファイルパス
+TEMPLATE_FILE="$1"
+OUTPUT_FILE="$2"
+
+if [ -z "$TEMPLATE_FILE" ] || [ -z "$OUTPUT_FILE" ]; then
+    echo "Usage: $0 <template_file> <output_file>"
+    exit 1
+fi
+
+if [ ! -f "$TEMPLATE_FILE" ]; then
+    echo "Error: Template file not found: $TEMPLATE_FILE"
+    exit 1
+fi
+
+# テンプレートファイルを読み込んで変数を展開
+echo "Processing iTerm2 configuration template..."
+
+# sedを使用して$USERを実際のユーザー名に置換
+sed "s|\$USER|$USER|g" "$TEMPLATE_FILE" > "$OUTPUT_FILE"
+
+echo "iTerm2 configuration processed successfully."
+echo "Output file: $OUTPUT_FILE"

--- a/scripts/setup_iterm2.sh
+++ b/scripts/setup_iterm2.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# iTerm2 Setup Script
+# This script installs iTerm2 and configures it with custom settings
+
+set -e
+
+echo "Setting up iTerm2..."
+
+# Install iTerm2 if not already installed
+if ! command -v brew &> /dev/null; then
+    echo "Error: Homebrew is not installed. Please install Homebrew first."
+    exit 1
+fi
+
+# Install iTerm2
+if ! brew list --cask iterm2 &> /dev/null; then
+    echo "Installing iTerm2..."
+    brew install --cask iterm2
+else
+    echo "iTerm2 is already installed."
+fi
+
+# Create iTerm2 preferences directory if it doesn't exist
+ITERM2_PREFS_DIR="$HOME/Library/Preferences"
+if [ ! -d "$ITERM2_PREFS_DIR" ]; then
+    mkdir -p "$ITERM2_PREFS_DIR"
+fi
+
+# Get the dotfiles directory
+DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Copy iTerm2 preferences
+echo "Copying iTerm2 preferences..."
+cp "$DOTFILES_DIR/iterm2/com.googlecode.iterm2.plist" "$ITERM2_PREFS_DIR/"
+
+# Set iTerm2 to load preferences from custom folder
+defaults write com.googlecode.iterm2 LoadPrefsFromCustomFolder -bool true
+defaults write com.googlecode.iterm2 PrefsCustomFolder -string "$DOTFILES_DIR/iterm2"
+
+# Install recommended font (MesloLGS NF)
+echo "Installing recommended font (MesloLGS NF)..."
+if ! brew list --cask font-meslo-lg-nerd-font &> /dev/null 2>&1; then
+    brew tap homebrew/cask-fonts 2>/dev/null || true
+    brew install --cask font-meslo-lg-nerd-font
+else
+    echo "MesloLGS NF font is already installed."
+fi
+
+echo "iTerm2 setup complete!"
+echo ""
+echo "Note: You may need to restart iTerm2 for all settings to take effect."
+echo "iTerm2 will now load preferences from: $DOTFILES_DIR/iterm2"

--- a/scripts/setup_iterm2.sh
+++ b/scripts/setup_iterm2.sh
@@ -30,9 +30,16 @@ fi
 # Get the dotfiles directory
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Copy iTerm2 preferences
-echo "Copying iTerm2 preferences..."
-cp "$DOTFILES_DIR/iterm2/com.googlecode.iterm2.plist" "$ITERM2_PREFS_DIR/"
+# Process and copy iTerm2 preferences
+echo "Processing and copying iTerm2 preferences..."
+if [ -f "$DOTFILES_DIR/scripts/process_iterm2_config.sh" ]; then
+    "$DOTFILES_DIR/scripts/process_iterm2_config.sh" \
+        "$DOTFILES_DIR/iterm2/com.googlecode.iterm2.plist" \
+        "$ITERM2_PREFS_DIR/com.googlecode.iterm2.plist"
+else
+    # フォールバック: 直接コピー
+    cp "$DOTFILES_DIR/iterm2/com.googlecode.iterm2.plist" "$ITERM2_PREFS_DIR/"
+fi
 
 # Set iTerm2 to load preferences from custom folder
 defaults write com.googlecode.iterm2 LoadPrefsFromCustomFolder -bool true


### PR DESCRIPTION
## 概要
iTerm2の設定ファイルとセットアップ環境を追加しました。

## 変更内容
- **Brewfile**: iTerm2を含む開発ツールの定義ファイルを新規作成
- **iTerm2設定ファイル**: 推奨設定を含むplistファイルを追加
- **セットアップスクリプト**: iTerm2とフォントの自動インストール・設定スクリプトを作成
- **ドキュメント**: READMEにiTerm2セクションを追加

## 設定の特徴
- ダークテーマのカスタムカラースキーム
- MesloLGS NFフォント（Powerline対応）
- スクロールバック10,000行
- tmux統合対応
- ホットキー設定済み

## テスト計画
- [ ] `brew bundle`でiTerm2が正常にインストールされることを確認
- [ ] `./scripts/setup_iterm2.sh`が正常に実行されることを確認
- [ ] iTerm2起動時に設定が適用されることを確認
- [ ] フォントが正しくインストールされることを確認

## 関連ISSUE
Closes #76